### PR TITLE
Copy .exes instead of symlinking them

### DIFF
--- a/movfs4l.py
+++ b/movfs4l.py
@@ -253,7 +253,12 @@ def updatelink(src, dest, log):
         log['backups'].append(dest)
     log['links'].insert(0, dest)
     #print ('Linking "%s" to "%s"' % (src, dest))
-    os.symlink(src, dest)
+
+    # wine can't handle symlinked exes (but dlls are fine)
+    if src.lower().endswith(".exe"):
+        shutil.copyfile(src, dest)
+    else:
+        os.symlink(src, dest)
 
 
 def mktree(root, path, log):


### PR DESCRIPTION
Wine can't run symlinked exes, so they must be copied. I guess they could be hard linked as well, but then we run into the possible separate drives issue.

If optional hardlink support is later added (#7), then this should probably be replaced to a hard link in those cases.