### PR TITLE
Implement configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.ini
+*~

--- a/movfs4l.py
+++ b/movfs4l.py
@@ -4,6 +4,9 @@ import sys
 import shutil
 import re
 import threading
+import configparser
+import copy
+import pprint
 try:
     # Much faster than python's default json module, makes reading and writing the log much quicker
     import ujson as json
@@ -83,6 +86,27 @@ def winpath(path):
     return os.path.join(winparent, basename)
 
 
+def winepath(prefix, path):
+    if "\\\\" in path:
+        path = path.replace("\\\\", "/")
+    elif "/" not in path:
+        # good enough for now
+        path = path.replace("\\", "/")
+
+    match = re.search(r"^([a-z]:)", path.lower())
+    if match:
+        path = re.sub("^..", os.path.join(prefix, "dosdevices", match.group(1)), path)
+
+    path = winpath(path)
+
+    return path
+
+
+def fullpath(path):
+    return os.path.realpath(os.path.expanduser(path))
+
+scriptdir = os.path.dirname(os.path.realpath(__file__))
+
 def ioyield():
     iodelay(.00001)
 
@@ -91,11 +115,424 @@ def get_terminal_width():
     return shutil.get_terminal_size()[0]
 
 
+def apply_variables(string, variables, processed={}):
+    if type(string) != str:
+        return string
+
+    newstring = ""
+    variable = None
+    for x in string:
+        if variable is not None:
+            if x == "}":
+                value = None
+
+                if variable in processed:
+                    if processed[variable] is None:
+                        print("Variable loop (%s), exiting" % variable)
+                        return sys.exit(1)
+                    else:
+                        value = processed[variable]
+
+                if value is None:
+                    processed[variable] = None
+                    value = apply_variables(variables[variable], variables, processed)
+                    processed[variable] = value
+
+                newstring += value
+                variable = None
+            else:
+                variable += x
+            continue
+        if x == "{":
+            variable = ""
+            continue
+        newstring += x
+    return newstring
+
+
+def get_used_variables(string, variables, used_variables=[]):
+    variable = None
+    for x in string:
+        if variable is not None:
+            if x == "}":
+                if variable not in used_variables:
+                    used_variables.append(variable)
+
+                    if variable in variables:
+                        get_used_variables(variables[variable], variables, used_variables)
+                variable = None
+            else:
+                variable += x
+            continue
+        if x == "{":
+            variable = ""
+            continue
+    return used_variables
+
+
+def fill_variables(variables):
+    for var in variables:
+        value = apply_variables(variables[var], variables)
+        variables[var] = value
+    return variables
+
+
+game_infos = {
+    "Generic": {
+        "vars": {
+            "default_profile": "Default",
+            "vfs_meta_log": "{game_path}/movfs4l_log.json"
+        },
+
+        "shortname": "Unknown",
+
+        "neededvars": [
+            "default_profile",
+            "vfs_meta_log"
+        ]
+    },
+
+    "GenericBethesda": {
+        "inherit": "Generic",
+
+        "shortname": "Unknown",
+
+        "vars": {
+            "default_profile": "Default",
+            "plugins_txt": "{gameappdata}/plugins.txt"
+        },
+
+        "vfs": [
+            {
+                "dest": "{game_path}/Data",
+                "path": "[mods]",
+                "name": "mods"
+            },
+
+            {
+                "dest": "{plugins_txt}",
+                "path": "{mo_profile}/plugins.txt",
+                "name": "plugins list"
+            }
+        ]
+    },
+
+    "Skyrim": {
+        "inherit": "GenericBethesda",
+
+        "shortname": "Skyrim",
+
+        "vars": {
+            "gameappdata": "{localappdata}/Skyrim",
+        }
+    },
+
+    "Skyrim Special Edition": {
+        "inherit": "GenericBethesda",
+
+        "shortname": "SkyrimSE",
+
+        "vars": {
+            "gameappdata": "{localappdata}/Skyrim Special Edition",
+            "loadorder_txt": "{gameappdata}/loadorder.txt"
+        },
+
+        "vfs": [
+            {
+                "dest": "{loadorder_txt}",
+                "path": "{mo_profile}/loadorder.txt",
+                "name": "load order"
+            }
+        ]
+    },
+
+    "Fallout 4": {
+        "inherit": "Skyrim Special Edition",
+
+        "shortname": "Fallout4",
+
+        "vars": {
+            "gameappdata": "{localappdata}/Fallout4"
+        }
+    }
+}
+
+
+def get_game_from_moroot(variables):
+    moini = os.path.join(variables["mo_gameroot"], "ModOrganizer.ini")
+
+    config = configparser.ConfigParser()
+    config.read(moini)
+
+    variables["game_name"] = config["General"]["gameName"]
+    variables["game_type"] = variables["game_name"]
+    variables["game_path"] = winepath(variables["wineprefix"], config["General"]["gamePath"])
+
+    if variables["game_type"] not in game_infos:
+        variables["game_type"] = "GenericBethesda"
+        print("Unknown game: %s" % variables["game_type"])
+        print("Defaulting to GenericBethesda. You will have to manually enter `gameappdata' in the configuration.")
+
+
+def fill_game_info(variables, game_type=None):
+    if game_type is None:
+        if variables["game_type"] not in game_infos:
+            print("Unknown game type `%s', exiting." % variables["game_type"])
+            return sys.exit(1)
+        game_type = variables["game_type"]
+
+    game_info = game_infos[game_type]
+
+    if "neededvars" not in game_info:
+        game_info["neededvars"] = []
+    if "vfs" not in game_info:
+        game_info["vfs"] = []
+
+    for var in game_info["vars"]:
+        if var not in variables:
+            variables[var] = game_info["vars"][var]
+
+    if "inherit" in game_info:
+        inherited = fill_game_info(variables, game_info["inherit"])
+        game_info["vfs"] = inherited["vfs"] + game_info["vfs"]
+
+        for entry in inherited.get("neededvars", []):
+            if entry not in game_info["neededvars"]:
+                game_info["neededvars"].append(entry)
+
+    # Remove duplicate entries (disabled for now as it's useless, and breaks overwrites)
+    """old_vfs = game_info["vfs"]
+    game_info["vfs"] = []
+    for entry in reversed(old_vfs):
+        skip = False
+        for gi_entry in game_info["vfs"]:
+            if entry["dest"] == gi_entry["dest"]:
+                skip = True
+                break
+        if skip:
+            continue
+        game_info["vfs"].insert(0, entry)"""
+
+    return game_info
+
+
+def get_wine_user(variables):
+    usersdir = winpath(os.path.join(variables["wineprefix"], "drive_c", "users"))
+
+    if "wineuser" not in variables:
+        users = []
+        for user in os.listdir(usersdir):
+            if user.lower() != "public":
+                users.append(user)
+
+        error = False
+        if len(users) > 1:
+            print("Too many users in %s, use the `wineuser' configuration option to specify the user." % variables["wineprefix"])
+            error = True
+        elif len(users) == 0:
+            print("No users under %s?" % variables["wineprefix"])
+            error = True
+
+        if error:
+            print("The script may still succeed if using a portable ModOrganizer setup, but you will need to manually set `localappdata'.")
+            return None
+
+        variables["wineuser"] = users[0]
+
+    if "winehome" not in variables:
+        winehome = winpath(os.path.join(usersdir, variables["wineuser"]))
+        if os.path.exists(winehome):
+            variables["winehome"] = winehome
+
+
+def find_localappdata(variables):
+    # https://github.com/wine-mirror/wine/blob/f0ad5b5c546d17b281aef13fde996cda08d0c14e/dlls/shell32/shellpath.c
+    searchpaths = [
+        "Local AppData",
+        "Local Settings/Application Data",
+        "AppData/Local"
+    ]
+
+    if "winehome" not in variables:
+        return
+
+    for path in searchpaths:
+        fullpath = winpath(os.path.join(variables["winehome"], path))
+        if os.path.exists(fullpath):
+            variables["localappdata"] = fullpath
+            break
+
+
+def find_mo_installroot(variables):
+    if "mo_installroot" in variables:
+        return variables["mo_installroot"]
+
+    installroot = winpath(os.path.join(variables["wineprefix"], "drive_c", "Modding", "MO2"))
+    if os.path.exists(installroot):
+        variables["mo_installroot"] = installroot
+        return installroot
+
+    print("Can't find MO installation path in current wineprefix (%s)\n" % variables["wineprefix"])
+    print("Either change WINEPREFIX or use the `mo_installroot' configuration option to specify a custom installation location.")
+    return None
+
+
+def find_mo_games(variables):
+    if "mo_installroot" not in variables:
+        return []
+
+    # Portable installation, don't look further
+    if os.path.exists(winpath(os.path.join(variables["mo_installroot"], "ModOrganizer.ini"))):
+        return [variables["mo_installroot"]]
+
+    if "winehome" in variables:
+        moroot = winpath(os.path.join(variables["winehome"], "Local Settings", "Application Data", "ModOrganizer"))
+        if os.path.exists(moroot):
+            games = []
+            for game in os.listdir(moroot):
+                fullgamedir = os.path.join(moroot, game)
+                if os.path.exists(winpath(os.path.join(fullgamedir, "ModOrganizer.ini"))):
+                    games.append(fullgamedir)
+            return games
+
+    return []
+
+
+def get_base_variables(variables):
+    if "WINEPREFIX" in os.environ:
+        variables["wineprefix"] = os.environ["WINEPREFIX"]
+    else:
+        variables["wineprefix"] = os.path.expanduser("~/.wine")
+
+    for var in os.environ:
+        if var.startswith("MO_"):
+            varname = var[3:]
+            if varname not in variables:
+                variables[varname] = os.environ[var]
+
+    if "mo_profile" not in variables:
+        variables["mo_profile"] = "{mo_gameroot}/profiles/{profile}"
+    if "mo_mods" not in variables:
+        variables["mo_mods"] = "{mo_gameroot}/mods"
+    if "mo_overwrite" not in variables:
+        variables["mo_overwrite"] = "{mo_gameroot}/overwrite"
+
+
+def generate_game_config(variables, gameinfo):
+    used_variables = [
+        "mo_gameroot",
+        "game_type"
+    ]
+
+    for entry in gameinfo.get("neededvars", []):
+        if entry not in used_variables:
+            used_variables.append(entry)
+
+    for entry in gameinfo["vfs"]:
+        get_used_variables(entry["dest"], variables, used_variables)
+        get_used_variables(entry["path"], variables, used_variables)
+
+    config = {}
+    for var in used_variables:
+        if var in variables:
+            config[var] = variables[var]
+
+    return config
+
+
+games = {}
+game = None
+
+
+def parse_config(variables):
+    inipath = os.path.join(scriptdir, "config.ini")
+    if not os.path.exists(inipath):
+        return generate_config(variables, inipath)
+
+    config = configparser.ConfigParser()
+    config.read(inipath)
+
+    get_base_variables(variables)
+
+    if "default" in config:
+        for var in config["default"]:
+            if var not in variables:
+                variables[var] = config["default"][var]
+
+    base_variables = variables
+
+    for var in config:
+        if not var.startswith("game/"):
+            continue
+
+        variables = copy.deepcopy(base_variables)
+
+        mogame = var[len("game/"):]
+        mogame_config = config[var]
+
+        for mvar in mogame_config:
+            if mvar not in variables:
+                variables[mvar] = mogame_config[mvar]
+
+        game_info = fill_game_info(variables)
+        game_info["vars"] = variables
+        games[mogame] = game_info
+
+
+def generate_config(variables, inipath):
+    get_base_variables(variables)
+
+    get_wine_user(variables)
+    find_localappdata(variables)
+    find_mo_installroot(variables)
+    games = find_mo_games(variables)
+
+    if len(games) == 0:
+        print("Unable to find any games")
+        sys.exit(1)
+
+    config = configparser.ConfigParser()
+
+    config["general"] = {
+        "iodelay": True
+    }
+
+    for game_path in games:
+        gamename = os.path.basename(game_path)
+        variables["mo_gameroot"] = game_path
+        get_game_from_moroot(variables)
+
+        gameinfo = fill_game_info(variables)
+
+        if gamename == "MO2":
+            # portable installation
+            gamename = gameinfo["shortname"]
+
+        config["game/" + gamename] = generate_game_config(variables, gameinfo)
+
+    with open(inipath, 'w') as inifile:
+        config.write(inifile)
+
+    print("Written auto-generated configuration to config.ini. Please check the file, then run this script again.")
+    sys.exit(0)
+
+
+def detect_game():
+    cwd = os.getcwd()
+    for game in games:
+        game_info = games[game]
+        game_path = fullpath(game_info["vars"]["game_path"])
+        if game_path in cwd:
+            return game
+    return None
+
+
 prettyprint_total = 0
 prettyprint_current = 0
 prettyprint_text = ""
 prettyprint_lock = threading.Lock()
 prettyprint_stop = False
+
 
 def prettyprint(progress, text):
     global prettyprint_current, prettyprint_text, prettyprint_lock
@@ -241,6 +678,27 @@ def apply_vfs(vfs, rootDir, vfs_path, log):
             apply_vfs(item_obj, rootDir, os.path.join(vfs_path, item_obj["name"]), log)
 
 
+vfs_log = {'dirs': [], 'links': [], 'backups': []}
+
+def apply_game_vfs():
+    global prettyprint_total, vfs_log
+
+    for entry in game["vfs"]:
+        plog("Linking %s" % entry["name"])
+        if entry["path"] == "[mods]":
+            prettyprint_total = vfs_total
+            t = start_prettyprint()
+            apply_vfs(vfs, entry["dest"], "", vfs_log)
+            stop_prettyprint(t)
+        else:
+            updatelink(entry["path"], entry["dest"], vfs_log)
+
+
+def write_vfs_log():
+    plog('Writing log')
+    with open(game["vars"]["vfs_meta_log"], 'w') as logfile:
+        logfile.write(json.dumps(vfs_log))
+
 
 def updatelink(src, dest, log):
     iodelay(0.0015)
@@ -249,7 +707,6 @@ def updatelink(src, dest, log):
         os.unlink(dest)
     elif os.path.exists(dest):
         shutil.move(dest, '%s.unvfs' % dest)
-        #print ('Backing up ', dest)
         log['backups'].append(dest)
     log['links'].insert(0, dest)
     #print ('Linking "%s" to "%s"' % (src, dest))
@@ -289,12 +746,16 @@ def pathHdlr(p):
 def unvfs(p):
     global prettyprint_total
 
-    if not os.path.exists('movfs4l_log.json'):
+    logpath = winpath(game["vars"]["vfs_meta_log"])
+    if not os.path.exists(logpath):
         return
 
-    plog("Reading movfs4l_log.json")
+    plog("Reading VFS meta log")
 
-    log = json.loads(open('movfs4l_log.json').read())
+    log = {}
+
+    with open(logpath) as logfile:
+        log = json.loads(logfile.read())
 
     head = p + "/"
 
@@ -338,7 +799,9 @@ def unvfs(p):
 
     plog("Clearing log")
     log = {'dirs': [], 'links': [], 'backups': []}
-    open('movfs4l_log.json', 'w').write(json.dumps(log, indent=4))
+
+    with open(logpath, 'w') as logfile:
+        logfile.write(json.dumps(log))
 
 
 def lowerpath(path):
@@ -367,7 +830,121 @@ def lowertree(dir):
         rename_all(root, files)
 
 
+def parsebool(value):
+    lowervalue = value.lower().strip()
+    if lowervalue == "true":
+        return True
+    if lowervalue == "false":
+        return False
+    return value
+
+
+boolargs = [
+    "unvfs"
+]
+
+def parseargs():
+    currentarg = None
+    variables = {}
+    for arg in sys.argv[1:]:
+        if arg.startswith("--") and currentarg is None:
+            currentarg = arg[2:]
+            if currentarg.lower() in boolargs:
+                variables[currentarg] = True
+                currentarg = None
+        elif currentarg is not None:
+            variables[currentarg] = arg
+            currentarg = None
+    return variables
+
+
 if __name__ == '__main__':
+    args = parseargs()
+    parse_config(args)
+
+    game = args.get("game", None)
+    gamename = None
+    if game is None:
+        game = detect_game()
+
+    if game is not None:
+        gamename = game
+        game = games[game]
+
+    if game is None:
+        print("Unable to detect game")
+        sys.exit(0)
+
+    args = game["vars"]
+    profile = None
+    if "profile" in args:
+        profile = args["profile"]
+    if profile is None:
+        profile = args.get("default_profile", "Default")
+
+    args["profile"] = profile
+
+    fill_variables(args)
+
+    if not os.path.exists(winpath(args["mo_profile"])):
+        print("Profile directory does not exist: %s" % args["mo_profile"])
+        sys.exit(1)
+
+    for entry in game["vfs"]:
+        entry["dest"] = apply_variables(entry["dest"], args)
+        entry["path"] = apply_variables(entry["path"], args)
+
+    if "iodelay" in game["vars"]:
+        IO_DELAY = parsebool(game["vars"]["iodelay"])
+        if type(IO_DELAY) is not bool:
+            IO_DELAY = True
+
+    plog('Removing VFS layer')
+    for entry in game["vfs"]:
+        if entry["path"] == "[mods]":
+            plog_indent += 1
+            unvfs(entry["dest"])
+            plog_indent -= 1
+
+    if "unvfs" in args and args["unvfs"] is True:
+        sys.exit(0)
+
+    plog('Parsing MO mods configuration')
+    modpaths = []
+    for i in open(winpath(os.path.join(args["mo_profile"], 'modlist.txt'))).readlines():
+        if i.startswith('+'):  # only enabled mods
+            modpaths.append(i[1:].strip())
+
+    modpaths = list(reversed(modpaths))
+
+    plog('Creating VFS index')
+    prettyprint_total = len(modpaths) + 1
+    i = 1
+    t = start_prettyprint()
+
+    for modname in modpaths:
+        prettyprint(i, modname)
+        add_vfs_layer(winpath(os.path.join(args["mo_mods"], modname)).strip())
+        i += 1
+
+    prettyprint(i, "(Overwrite)")
+    add_vfs_layer(winpath(args["mo_overwrite"]))
+    i += 1
+
+    stop_prettyprint(t)
+
+    apply_game_vfs()
+    write_vfs_log()
+
+    print("")
+    plog('VFS layer created. Run "%s --game %s --profile %s --unvfs" to shut it down (run this before running Mod Organizer again)' % (
+        sys.argv[0],
+        gamename,
+        profile
+    ))
+
+    sys.exit(0)
+
     log = {'dirs': [], 'links': [], 'backups': []}
     DATADIR=os.path.join(pathHdlr(PATHS['skyrim']), 'Data')
     lowertree(DATADIR)

--- a/movfs4l.py
+++ b/movfs4l.py
@@ -722,7 +722,6 @@ def unvfs(p):
         l = winpath(l)
         if os.path.islink(l):
             prettyprint(i, l.replace(head, ""))
-            #print ('Removing symlink ', l)
             iodelay(0.0005)
             os.unlink(l)
         i += 1
@@ -735,9 +734,9 @@ def unvfs(p):
     for d in log['dirs']:
         d = winpath(d)
         if os.path.isdir(d):
-            prettyprint(i, d.replace(head, ""))
-            #print ('Removing directory ', d)
-            shutil.rmtree(d)
+            if not os.listdir(d):
+                prettyprint(i, d.replace(head, ""))
+                shutil.rmtree(d)
         i += 1
     stop_prettyprint(t)
 


### PR DESCRIPTION
This implements #9, using a configuration file beside the script (`config.ini`), which is automatically generated based off your WINEPREFIX. You can also generate it again for other WINEPREFIXes (through `--generate_config`), which will append whatever new games it finds to `config.ini`.

All of the options that were previously available in the code are still available through the configuration system, as well as a few more (such as where you want the `movfs4l_log.json` to be located, it defaults to the game directory).

If you run it in a game directory, it will automatically choose that game (unless you specify another using `--game [gamename]`). Otherwise, you will have to specify the game manually (currently not documented, will add that later).

The default profile can be modified through the `default_profile`, which defaults to "Default". You can of course change the actual profile at runtime, via `--profile [profilename]`.

In fact, any of the options can be modified at runtime, either via `--` options, or through environmental variables (`MO_option=value`).

It also links `loadorder.txt` for Fallout 4 and Skyrim SE (following MO's actual behavior for the titles), and allows for a relatively flexible (although hardcoded) system to add custom support for new games.

I also fixed #10 and #6 while I was at it.

I have tested this with Skyrim, without any issues, but I haven't tested this with Fallout 4 yet.