### PR TITLE
Option to create hardlinks instead of symlinks

### DIFF
--- a/movfs4l.py
+++ b/movfs4l.py
@@ -19,6 +19,12 @@ except Exception:
 def iodelay(s):
     pass
 
+"""
+Ideas:
+- if file exists and is not in log, don't overwrite (NFIS, Caliente)
+- convert all directories to lowerpath - always bugged me
+"""
+
 
 use_lower = False
 pathcache = {}
@@ -53,6 +59,8 @@ def create_link(src, dst):
 
 def remove_link(path):
     global use_hardlinks, vfs_log
+    if not os.path.exists(path):
+        return
     if use_hardlinks:
         if (is_link(path)):
             os.remove(path)

--- a/movfs4l.py
+++ b/movfs4l.py
@@ -441,10 +441,8 @@ game_binaries_csv = ",".join(game_binaries)
 # based on code shared by smirgol: https://github.com/qsniyg/ksp_stuff/issues/31
 def remove_bytearray(var):
     newvar = re.sub(r"^@ByteArray\(", "", var)
-    print(var)
-    print(newvar)
     if newvar == var:
-       return var
+        return var
 
     return re.sub(r"\)$", "", newvar)
 
@@ -456,7 +454,7 @@ def get_game_from_moroot(variables):
     config.read(moini)
 
     config["General"]["gamePath"] = remove_bytearray(config["General"]["gamePath"])
-    print(config["General"]["gamePath"])
+
     variables["game_name"] = config["General"]["gameName"]
     variables["game_type"] = variables["game_name"]
     variables["game_path"] = winepath(variables["wineprefix"], config["General"]["gamePath"])
@@ -1307,6 +1305,7 @@ if __name__ == '__main__':
         perr("Profile directory does not exist: %s" % args["mo_profile"])
         sys.exit(1)
 
+    plog('Removing VFS layer')
     for entry in game["vfs"]:
         if "disabled" in entry:
             continue


### PR DESCRIPTION
If interested, I've patched your script to create hard-links instead of symlinks. It's triggered with:
`--hard_links`. If omitted, it will create the usual symlinks.

It can be omitted when calling `--unvfs`, as the option is written to the logfile, so hard-links can properly be cleaned up if the user used that option when creating the links but forgot to specify the option when asking for a clean-up.
Of course it will only work if both `src` and `dst` are on the same drive, I have not added a check for that, might be a good idea though...

I also added a few calls to `close()` whenever a file has been opened for reading/writing. Not sure if absolutely necessary, but I thought it might be a good idea. Then I've replaced the calls to create/check/remove links with new functions, as I needed to add additional logic to the checks to handle hard-links and its cleaner that way.
Finally, the log file is now read earlier, as I require its data for the various checks in the new functions. I left in the additional check in you function when removing the vfs, but moved the reading of the log to the main function.

The pull requests consist of 2 commits, as I forgot to remove some debug prints() on my first commit, as usual. :)